### PR TITLE
Fix WKB polygon reading

### DIFF
--- a/src/GeometryConversions.Shared/Wkb/WkbConverter.Read.cs
+++ b/src/GeometryConversions.Shared/Wkb/WkbConverter.Read.cs
@@ -230,10 +230,10 @@ namespace GeometryConversions.Wkb
 				// TODO: Validate type
 
 				int numRings = (int)readUInt32(reader, byteOrder);
-			    foreach (var ring in CoordinateCollectionEnumerator(numRings, reader, byteOrder, type, spatialReference))
-			    {
-			        rings.Add(new List<MapPoint>(ring));
-			    }
+				foreach (var ring in CoordinateCollectionEnumerator(numRings, reader, byteOrder, type, spatialReference))
+				{
+					rings.Add(new List<MapPoint>(ring));
+				}
 			}
 
 			//Create and return the MultiPolygon.

--- a/src/GeometryConversions.Shared/Wkb/WkbConverter.Read.cs
+++ b/src/GeometryConversions.Shared/Wkb/WkbConverter.Read.cs
@@ -150,13 +150,12 @@ namespace GeometryConversions.Wkb
 		{
 			// Get the Number of rings in this Polygon.
 			int numRings = (int)readUInt32(reader, byteOrder);
-		    List<IEnumerable<MapPoint>> rings = new List<IEnumerable<MapPoint>>();
-		    foreach (var ring in CoordinateCollectionEnumerator(numRings, reader, byteOrder, type, null))
-		    {
-		        rings.Add(new List<MapPoint>(ring));
-		    }
+			List<IEnumerable<MapPoint>> rings = new List<IEnumerable<MapPoint>>();
+			foreach (var ring in CoordinateCollectionEnumerator(numRings, reader, byteOrder, type, null))
+			{
+				rings.Add(new List<MapPoint>(ring));
+			}
 			return new Polygon(rings, spatialReference);
-			
 		}
 
 		IEnumerable<IEnumerable<MapPoint>> CoordinateCollectionEnumerator(int count, BinaryReader reader, WkbByteOrder byteOrder, WkbGeometryType type, SpatialReference spatialReference)
@@ -186,7 +185,6 @@ namespace GeometryConversions.Wkb
 				points.Add(ReadWkbPoint(reader, byteOrder, type, null));
 			}
 			return new Multipoint(points, spatialReference);
-			
 		}
 
 		private Polyline ReadWkbMultiLineString(BinaryReader reader, WkbByteOrder byteOrder, WkbGeometryType type, SpatialReference spatialReference)

--- a/src/GeometryConversions.Shared/Wkb/WkbConverter.Read.cs
+++ b/src/GeometryConversions.Shared/Wkb/WkbConverter.Read.cs
@@ -150,14 +150,21 @@ namespace GeometryConversions.Wkb
 		{
 			// Get the Number of rings in this Polygon.
 			int numRings = (int)readUInt32(reader, byteOrder);
-			return new Polygon(CoordinateCollectionEnumerator(numRings + 1, reader, byteOrder, type, null), spatialReference);
+		    List<IEnumerable<MapPoint>> rings = new List<IEnumerable<MapPoint>>();
+		    foreach (var ring in CoordinateCollectionEnumerator(numRings, reader, byteOrder, type, null))
+		    {
+		        rings.Add(new List<MapPoint>(ring));
+		    }
+			return new Polygon(rings, spatialReference);
 			
 		}
+
 		IEnumerable<IEnumerable<MapPoint>> CoordinateCollectionEnumerator(int count, BinaryReader reader, WkbByteOrder byteOrder, WkbGeometryType type, SpatialReference spatialReference)
 		{
 			for(int i=0;i<count;i++)
 				yield return ReadCoordinates(reader, byteOrder, type, spatialReference);
 		}
+
 		private Multipoint ReadWkbMultiPoint(BinaryReader reader, WkbByteOrder byteOrder, WkbGeometryType type, SpatialReference spatialReference)
 		{
 			// Get the number of points in this multipoint.
@@ -225,7 +232,10 @@ namespace GeometryConversions.Wkb
 				// TODO: Validate type
 
 				int numRings = (int)readUInt32(reader, byteOrder);
-				rings.AddRange(CoordinateCollectionEnumerator(numRings + 1, reader, byteOrder, type, spatialReference));
+			    foreach (var ring in CoordinateCollectionEnumerator(numRings, reader, byteOrder, type, spatialReference))
+			    {
+			        rings.Add(new List<MapPoint>(ring));
+			    }
 			}
 
 			//Create and return the MultiPolygon.

--- a/src/UnitTests.Shared/WkbTests.cs
+++ b/src/UnitTests.Shared/WkbTests.cs
@@ -74,5 +74,60 @@ namespace UnitTests
 			Assert.AreEqual(56, mp2.Z);
 			Assert.AreEqual(78, mp2.M);
         }
+
+        [TestMethod]
+        public void WkbConvertPolygonToFromXY()
+        {
+            MapPoint mp1 = new MapPoint(11, 12);
+            MapPoint mp2 = new MapPoint(21, 22);
+            MapPoint mp3 = new MapPoint(31, 32);
+            Polygon poly = new Polygon(new [] {mp1, mp2, mp3});
+            byte[] bytes = poly.ToWellKnownBinary();
+            var geom = bytes.FromWellKnownBinary();
+            Assert.IsNotNull(geom);
+            Assert.IsInstanceOfType(geom, typeof(Polygon));
+            Polygon poly2 = (Polygon)geom;
+            Assert.IsFalse(poly2.HasZ);
+            Assert.IsFalse(poly2.HasM);
+            Assert.AreEqual(1, poly2.Parts.Count);
+            Assert.AreEqual(3, poly2.Parts[0].Points.Count);
+            Assert.AreEqual(31, poly2.Parts[0].Points[2].X);
+            Assert.AreEqual(32, poly2.Parts[0].Points[2].Y);
+        }
+
+        [TestMethod]
+        public void WkbConvertMultiPolygonToFromXY()
+        {
+            // Poly with 1 outer and 1 inner ring
+            MapPoint mp1o = new MapPoint(1, 2);
+            MapPoint mp2o = new MapPoint(1, 200);
+            MapPoint mp3o = new MapPoint(100, 200);
+            MapPoint mp4o = new MapPoint(100, 2);
+            MapPoint mp1i = new MapPoint(3, 40);
+            MapPoint mp2i = new MapPoint(30, 40);
+            MapPoint mp3i = new MapPoint(30, 4);
+            MapPoint mp4i = new MapPoint(3, 4);
+            Polygon poly = new Polygon(new[]
+                {
+                    new[] { mp1o, mp2o, mp3o, mp4o },
+                    new[] { mp1i, mp2i, mp3i, mp4i }
+                }
+            );
+
+            byte[] bytes = poly.ToWellKnownBinary();
+            var geom = bytes.FromWellKnownBinary();
+            Assert.IsNotNull(geom);
+            Assert.IsInstanceOfType(geom, typeof(Polygon));
+            Polygon poly2 = (Polygon)geom;
+            Assert.IsFalse(poly2.HasZ);
+            Assert.IsFalse(poly2.HasM);
+            Assert.AreEqual(2, poly2.Parts.Count);
+            Assert.AreEqual(4, poly2.Parts[0].Points.Count);
+            Assert.AreEqual(4, poly2.Parts[1].Points.Count);
+            Assert.AreEqual(1, poly2.Parts[0].Points[0].X);
+            Assert.AreEqual(2, poly2.Parts[0].Points[0].Y);
+            Assert.AreEqual(3, poly2.Parts[1].Points[3].X);
+            Assert.AreEqual(4, poly2.Parts[1].Points[3].Y);
+        }
     }
 }

--- a/src/UnitTests.Shared/WkbTests.cs
+++ b/src/UnitTests.Shared/WkbTests.cs
@@ -75,59 +75,59 @@ namespace UnitTests
 			Assert.AreEqual(78, mp2.M);
         }
 
-        [TestMethod]
-        public void WkbConvertPolygonToFromXY()
-        {
-            MapPoint mp1 = new MapPoint(11, 12);
-            MapPoint mp2 = new MapPoint(21, 22);
-            MapPoint mp3 = new MapPoint(31, 32);
-            Polygon poly = new Polygon(new [] {mp1, mp2, mp3});
-            byte[] bytes = poly.ToWellKnownBinary();
-            var geom = bytes.FromWellKnownBinary();
-            Assert.IsNotNull(geom);
-            Assert.IsInstanceOfType(geom, typeof(Polygon));
-            Polygon poly2 = (Polygon)geom;
-            Assert.IsFalse(poly2.HasZ);
-            Assert.IsFalse(poly2.HasM);
-            Assert.AreEqual(1, poly2.Parts.Count);
-            Assert.AreEqual(3, poly2.Parts[0].Points.Count);
-            Assert.AreEqual(31, poly2.Parts[0].Points[2].X);
-            Assert.AreEqual(32, poly2.Parts[0].Points[2].Y);
-        }
+		[TestMethod]
+		public void WkbConvertPolygonToFromXY()
+		{
+			MapPoint mp1 = new MapPoint(11, 12);
+			MapPoint mp2 = new MapPoint(21, 22);
+			MapPoint mp3 = new MapPoint(31, 32);
+			Polygon poly = new Polygon(new[] { mp1, mp2, mp3 });
+			byte[] bytes = poly.ToWellKnownBinary();
+			var geom = bytes.FromWellKnownBinary();
+			Assert.IsNotNull(geom);
+			Assert.IsInstanceOfType(geom, typeof(Polygon));
+			Polygon poly2 = (Polygon)geom;
+			Assert.IsFalse(poly2.HasZ);
+			Assert.IsFalse(poly2.HasM);
+			Assert.AreEqual(1, poly2.Parts.Count);
+			Assert.AreEqual(3, poly2.Parts[0].Points.Count);
+			Assert.AreEqual(31, poly2.Parts[0].Points[2].X);
+			Assert.AreEqual(32, poly2.Parts[0].Points[2].Y);
+		}
 
-        [TestMethod]
-        public void WkbConvertMultiPolygonToFromXY()
-        {
-            // Poly with 1 outer and 1 inner ring
-            MapPoint mp1o = new MapPoint(1, 2);
-            MapPoint mp2o = new MapPoint(1, 200);
-            MapPoint mp3o = new MapPoint(100, 200);
-            MapPoint mp4o = new MapPoint(100, 2);
-            MapPoint mp1i = new MapPoint(3, 40);
-            MapPoint mp2i = new MapPoint(30, 40);
-            MapPoint mp3i = new MapPoint(30, 4);
-            MapPoint mp4i = new MapPoint(3, 4);
-            Polygon poly = new Polygon(new[]
-                {
-                    new[] { mp1o, mp2o, mp3o, mp4o },
-                    new[] { mp1i, mp2i, mp3i, mp4i }
-                }
-            );
+		[TestMethod]
+		public void WkbConvertMultiPolygonToFromXY()
+		{
+			// Poly with 1 outer and 1 inner ring
+			MapPoint mp1o = new MapPoint(1, 2);
+			MapPoint mp2o = new MapPoint(1, 200);
+			MapPoint mp3o = new MapPoint(100, 200);
+			MapPoint mp4o = new MapPoint(100, 2);
+			MapPoint mp1i = new MapPoint(3, 40);
+			MapPoint mp2i = new MapPoint(30, 40);
+			MapPoint mp3i = new MapPoint(30, 4);
+			MapPoint mp4i = new MapPoint(3, 4);
+			Polygon poly = new Polygon(new[]
+				{
+					new[] { mp1o, mp2o, mp3o, mp4o },
+					new[] { mp1i, mp2i, mp3i, mp4i }
+				}
+			);
 
-            byte[] bytes = poly.ToWellKnownBinary();
-            var geom = bytes.FromWellKnownBinary();
-            Assert.IsNotNull(geom);
-            Assert.IsInstanceOfType(geom, typeof(Polygon));
-            Polygon poly2 = (Polygon)geom;
-            Assert.IsFalse(poly2.HasZ);
-            Assert.IsFalse(poly2.HasM);
-            Assert.AreEqual(2, poly2.Parts.Count);
-            Assert.AreEqual(4, poly2.Parts[0].Points.Count);
-            Assert.AreEqual(4, poly2.Parts[1].Points.Count);
-            Assert.AreEqual(1, poly2.Parts[0].Points[0].X);
-            Assert.AreEqual(2, poly2.Parts[0].Points[0].Y);
-            Assert.AreEqual(3, poly2.Parts[1].Points[3].X);
-            Assert.AreEqual(4, poly2.Parts[1].Points[3].Y);
-        }
-    }
+			byte[] bytes = poly.ToWellKnownBinary();
+			var geom = bytes.FromWellKnownBinary();
+			Assert.IsNotNull(geom);
+			Assert.IsInstanceOfType(geom, typeof(Polygon));
+			Polygon poly2 = (Polygon)geom;
+			Assert.IsFalse(poly2.HasZ);
+			Assert.IsFalse(poly2.HasM);
+			Assert.AreEqual(2, poly2.Parts.Count);
+			Assert.AreEqual(4, poly2.Parts[0].Points.Count);
+			Assert.AreEqual(4, poly2.Parts[1].Points.Count);
+			Assert.AreEqual(1, poly2.Parts[0].Points[0].X);
+			Assert.AreEqual(2, poly2.Parts[0].Points[0].Y);
+			Assert.AreEqual(3, poly2.Parts[1].Points[3].X);
+			Assert.AreEqual(4, poly2.Parts[1].Points[3].Y);
+		}
+	}
 }


### PR DESCRIPTION
- Fixes a couple problems with reading polygon and multipolygon.
    - Fix off-by-1 error in the number of rings.
    - Avoid non-resettable IEnumerables when passing points to Runtime MultiPart constructor.
- Adds unit tests for reading polygons and multipolygons, now passing.